### PR TITLE
Add non-interactive commands on ironic-oneview-cli

### DIFF
--- a/.eggs/README.txt
+++ b/.eggs/README.txt
@@ -1,0 +1,6 @@
+This directory contains eggs that were downloaded by setuptools to build, test, and run plug-ins.
+
+This directory caches those eggs to prevent repeated downloads.
+
+However, it is safe to delete this directory.
+

--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@ coverage.xml
 
 # Sphinx documentation
 docs/_build/
+
+# Swap files
+*.swp

--- a/README.md
+++ b/README.md
@@ -79,7 +79,19 @@ Once the necessary environment variables and command line parameters are set, Ir
 <td align="left"><blockquote>
 <p>port-create</p>
 </blockquote></td>
-<td align="left">Creates a new Ironic Port based on available Ironic nodes.</td>
+<td align="left">Creates a Ironic Port based on available Ironic nodes.</td>
+</tr>
+<tr class="even">
+<td align="left"><blockquote>
+<p>server-profile-template-list</p>
+</blockquote></td>
+<td align="left">Lists HPE OneView Server Profile Templates.</td>
+</tr>
+<tr class="odd">
+<td align="left"><blockquote>
+<p>server-hardware-list</p>
+</blockquote></td>
+<td align="left">Lists HPE OneView Server Hardware.</td>
 </tr>
 <tr class="even">
 <td align="left"><blockquote>
@@ -143,9 +155,9 @@ This command also creates an Ironic port to be used by the node, the port is cre
 
 * * * * *
 
-Alternatively, the `Server Profile Template` can be specified using the parameter `--server-profile-template` so that the tool prompts the list of `Server Hardware` to be used, as shown in the following command:
+Alternatively, the `Server Profile Template` and `Server Hardware` can be specified using the parameters `--server-profile-template` and `--server-hardware-uuid` respectively, as shown in the following command:
 
-    $ ironic-oneview node-create [--server-profile-template-name | -spt <spt_name>]
+    $ ironic-oneview node-create [--server-profile-template | -t <spt>] [--server-hardware-uuid | -s <server_hardware>]
 
 A collection of nodes sharing the same `Server Profile Template` can be set up in a batch by using the following command:
 
@@ -199,6 +211,10 @@ The tool will prompt with a list of possible new flavors, according to the confi
 
 After choosing a valid configuration, the user can optionally specify a name for the new flavor. If left blank, a default name will be used. Additional information from Server Hardware Type, Enclosure Group and Server Profile Template is automatically added by default to the flavor metadata. Use Horizon to delete the Enclosure Group info, for example, so that a flavor matches Server Hardware in all available enclosures.
 
+Alternatively, you can set a `Ironic node`, and optionally `flavor name` through the command:
+
+    $ ironic-oneview flavor-create [--node <node>] [--name <name>]
+
 * * * * *
 
 To list all flavors in Nova, use the command:
@@ -224,6 +240,18 @@ To list all ports in Ironic, use the command:
 For more information about the created Ironic port, use the following command:
 
     $ openstack baremetal port show <port>
+
+### Server Profile Template List
+
+The tool offers a command to list `Server Profile Templates`. For that use the following command:
+
+    $ ironic-oneview server-profile-template-list
+
+### Server Hardware List
+
+The tool offers a command to list `Server Hardware` compatible with a specific `Server Profile Template`. For that use the following command:
+
+    $ ironic-oneview server-hardware-list
 
 ### Node delete
 

--- a/ironic_oneview_cli/create_node_shell/commands.py
+++ b/ironic_oneview_cli/create_node_shell/commands.py
@@ -22,11 +22,15 @@ from ironic_oneview_cli import facade
 
 
 class NodeCreator(object):
-    def __init__(self, node_facade):
-        self.facade = node_facade
+    def __init__(self, facade_obj):
+        self.facade = facade_obj
 
     def get_oneview_nodes(self):
         return common.get_oneview_nodes(self.facade.get_ironic_node_list())
+
+    @staticmethod
+    def is_server_profile_applied(server_hardware):
+        return bool(server_hardware.get('serverProfileUri'))
 
     def is_enrolled_on_ironic(self, server_hardware):
         nodes = self.get_oneview_nodes()
@@ -36,32 +40,34 @@ class NodeCreator(object):
 
     def set_attributes_to_object(self, oneview_object_list):
         for oneview_object in oneview_object_list:
+            enclosure_group_uri = oneview_object.get('enclosureGroupUri')
+            server_group_uri = oneview_object.get("serverGroupUri")
             enclosure_group = self.facade.get_enclosure_group(
-                oneview_object.get('enclosureGroupUri')
-            )
+                enclosure_group_uri or server_group_uri)
+
             server_hardware_type = self.facade.get_server_hardware_type(
-                oneview_object.get('serverHardwareTypeUri')
-            )
+                oneview_object.get('serverHardwareTypeUri'))
+            processor_core_count = oneview_object.get("processorCoreCount", 0)
+            processor_count = oneview_object.get("processorCount", 0)
 
             # Here comes the infamous HACK of local_gb and cpu_arch
             oneview_object["local_gb"] = 120
-
             oneview_object["cpu_arch"] = 'x86_64'
+
+            oneview_object["uuid"] = common.get_uuid_from_uri(
+                oneview_object.get("uri"))
+
+            oneview_object["cpus"] = processor_core_count * processor_count
+            oneview_object["memory_mb"] = common.get_attribute_from_dict(
+                oneview_object, "memoryMb")
+
             oneview_object["enclosure_group_name"] = (
                 common.get_attribute_from_dict(enclosure_group, 'name'))
             oneview_object["server_hardware_type_name"] = (
                 common.get_attribute_from_dict(server_hardware_type, 'name'))
 
             oneview_object['enrolled'] = self.is_enrolled_on_ironic(
-                oneview_object
-            )
-
-    def get_templates_compatible_with(self, server_hardware_objects):
-        spt_list = self.facade.list_templates_compatible_with(
-            server_hardware_objects
-        )
-
-        return sorted(spt_list, key=lambda x: x.get('name').lower())
+                oneview_object)
 
     def get_server_hardware_list(self, server_profile_template):
         selected_sht_uri = server_profile_template.get(
@@ -77,16 +83,19 @@ class NodeCreator(object):
             server_hardware_list = (
                 self.facade.filter_server_hardware_available(
                     [enclosure_group_uri, hardware_type_uri]))
-        else:
+        elif selected_sht_uri:
             # NOTE(fellypefca): Rack Servers are not in any enclosure
             server_hardware_list = (
                 self.facade.filter_server_hardware_available(
                     [hardware_type_uri]))
+        else:
+            server_hardware_list = (
+                self.facade.filter_server_hardware_available())
         return sorted(
             server_hardware_list, key=lambda x: x.get('name').lower())
 
     def create_node(self, args, server_hardware, server_profile_template):
-        attrs = common.create_attrs_for_node(
+        attrs = self._create_attrs_for_node(
             args, server_hardware, server_profile_template)
         common.update_attrs_for_node(attrs, args, server_hardware)
         node = self.facade.create_ironic_node(**attrs)
@@ -98,17 +107,46 @@ class NodeCreator(object):
 
         return node
 
+    @staticmethod
+    def _create_attrs_for_node(
+        args, server_hardware, server_profile_template
+    ):
+        if args.name and not common.is_valid_logical_name(args.name):
+            msg = "The name '%s' is not a valid logical name." % args.name
+            raise Exception(msg)
+
+        if args.name:
+            name = args.name
+        else:
+            name = common.normalize_logical_name(server_hardware.get('name'))
+
+        attrs = common.create_attrs_for_node(args, server_hardware, (
+                                             server_profile_template))
+        attrs['name'] = name
+
+        return attrs
+
 
 @common.arg(
     '-n', '--number',
     metavar='<number>',
     type=int,
-    help='Create n nodes based on a given HP OneView Server Profile Template.')
+    help='Create n nodes based on a given HPE OneView '
+         'Server Profile Template.')
 @common.arg(
-    '-spt', '--server-profile-template-name',
-    metavar='<spt_name>',
+    '--name',
+    metavar='<name>',
+    help='Name of the Ironic node being created.')
+@common.arg(
+    '-t', '--server-profile-template',
+    metavar='<spt>',
     default=None,
-    help='Name of the HP OneView Server Profile Template.')
+    help='Name, UUID or URI of the HPE OneView Server Profile Template.')
+@common.arg(
+    '-s', '--server-hardware-uuid',
+    metavar='<server_hardware>',
+    default=None,
+    help='URI or UUID of the HPE OneView Server Hardware.')
 @common.arg(
     '--use-oneview-ml2-driver',
     action='store_true',
@@ -123,21 +161,213 @@ class NodeCreator(object):
     '-m', '--mac',
     help='MAC Address of the HPE OneView Server Hardware.')
 def do_node_create(args):
-    """Create nodes based on available HP OneView Objects."""
+    """Create nodes based on available HPE OneView Objects."""
     facade_obj = facade.Facade(args)
     node_creator = NodeCreator(facade_obj)
 
-    spt_list = node_creator.get_templates_compatible_with(
-        facade_obj.filter_server_hardware_available()
-    )
+    try:
+        server_hardware = (
+            facade_obj.get_server_hardware(args.server_hardware_uuid)
+        )
+    except Exception:
+        print(("Could not find a Server Hardware matching "
+              "'%s'") % args.server_hardware_uuid)
+        return
+
+    server_hardware_list = [server_hardware] if server_hardware else None
+
+    try:
+        spt_list = facade_obj.list_templates_compatible(server_hardware_list)
+    except Exception:
+        print(("Unable to retrieve Server Profile Template "
+              "'%s'") % args.server_profile_template)
+        return
+
+    node_creator.set_attributes_to_object(spt_list)
+    common.assign_elements_with_new_id(spt_list)
+
+    if not args.server_profile_template:
+        template_selected = _interactive_template(spt_list)
+    else:
+        templates = facade_obj.list_all_templates()
+        node_creator.set_attributes_to_object(templates)
+        is_valid_spt = common.is_valid_spt(templates, (
+                                           args.server_profile_template))
+
+        if not is_valid_spt:
+            print(("Server Profile template is not valid "
+                  "'%s'") % args.server_profile_template)
+            return
+
+        template_selected = common.get_element(
+            spt_list, args.server_profile_template
+        )
+
+        if not template_selected:
+            print(("Server Hardware '%s' does not match the Server Hardware "
+                   "Type specified in this Server Profile Template '%s'")
+                  % (args.server_hardware_uuid, args.server_profile_template))
+            return
+
+    s_hardware_list = node_creator.get_server_hardware_list(template_selected)
+    node_creator.set_attributes_to_object(s_hardware_list)
+    common.assign_elements_with_new_id(s_hardware_list)
+
+    passed_server_hardware = None
+    if args.server_hardware_uuid:
+        passed_server_hardware = common.get_element(
+            s_hardware_list, args.server_hardware_uuid
+        )
+        if passed_server_hardware is None:
+            print(("Server Hardware (%(sh)s) does not match the Server "
+                   "Hardware Type specified in this Server Profile Template "
+                   "(%(spt)s)") % {'sh': args.server_hardware_uuid,
+                                   'spt': args.server_profile_template})
+            return
+
+    if args.mac and not common.is_valid_mac_address(args.mac):
+        print(("The node could not be created. "
+              "'%s' is not a valid MAC address.") % args.mac)
+        return
+
+    if args.number and not passed_server_hardware:
+        print(("Creating %(number_of_nodes)s nodes with the specific "
+               "Server Hardware") % {'number_of_nodes': args.number})
+        common.print_prompt(
+            [s_hardware_list[0]],
+            [
+                'cpus',
+                'memory_mb',
+                'local_gb',
+                'cpu_arch',
+                'enclosure_group_name',
+                'server_hardware_type_name'
+            ],
+            field_labels=[
+                'CPUs',
+                'Memory MB',
+                'Local GB',
+                'CPU Arch',
+                'Enclosure Group Name',
+                'Server Hardware Type Name'
+            ]
+        )
+
+        nodes_created = 0
+        for node_index in range(args.number):
+            node = common.get_element_by_id(s_hardware_list, node_index + 1)
+
+            if not node:
+                print("{} nodes created.".format(nodes_created))
+                break
+            elif node_creator.is_enrolled_on_ironic(node):
+                print(('Server Hardware %(server_hardware)s is already '
+                       'enrolled on Ironic.') % {'server_hardware':
+                                                 node.get("uuid")})
+            else:
+                if node_creator.is_server_profile_applied(node):
+                    print(('Server Hardware %(server_hardware)s is in use by '
+                           'OneView.') % {'server_hardware':
+                                          node.get("uuid")})
+
+                node_creator.create_node(args, node, template_selected)
+                nodes_created += 1
+
+        print('Node Creation Finished.')
+
+    else:
+        if not passed_server_hardware:
+            selected_server_hardware_list = _interactive_server_hardware(
+                s_hardware_list)
+        else:
+            selected_server_hardware_list = [passed_server_hardware]
+
+        not_enrolled_server_hardware = _remove_ironic_enrolled(
+            node_creator, selected_server_hardware_list)
+
+        _create_nodes(node_creator, not_enrolled_server_hardware, args,
+                      template_selected)
+
+
+def do_server_profile_template_list(args):
+    """List Server Profile Templates of HPE OneView."""
+    facade_obj = facade.Facade(args)
+    node_creator = NodeCreator(facade_obj)
+
+    spt_list = facade_obj.list_templates_compatible()
     node_creator.set_attributes_to_object(spt_list)
 
-    common.assign_elements_with_new_id(spt_list)
-    template_selected = common.get_element_by_name(
-        spt_list, args.server_profile_template_name
+    common.print_prompt(
+        spt_list,
+        [
+            'uuid',
+            'name',
+            'enclosure_group_name',
+            'server_hardware_type_name'
+        ],
+        field_labels=[
+            'UUID',
+            'Name',
+            'Enclosure Group Name',
+            'Server Hardware Type Name'
+        ]
     )
 
-    while template_selected is None:
+
+@common.arg(
+    '-t', '--server-profile-template',
+    metavar='<spt>',
+    help='Name or UUID of the HPE OneView Server Profile Template.')
+def do_server_hardware_list(args):
+    """List Server Hardware of HPE OneView."""
+    facade_obj = facade.Facade(args)
+    node_creator = NodeCreator(facade_obj)
+
+    spt_list = facade_obj.list_templates_compatible()
+    node_creator.set_attributes_to_object(spt_list)
+
+    template_selected = {}
+    if args.server_profile_template:
+        template_selected = common.get_element(
+            spt_list, args.server_profile_template
+        )
+
+        if template_selected is None:
+            print(("Could not find a Server Profile Template matching "
+                  "'%s'") % args.server_profile_template)
+            return
+
+    s_hardware_list = node_creator.get_server_hardware_list(
+        template_selected
+    )
+    node_creator.set_attributes_to_object(s_hardware_list)
+
+    common.print_prompt(
+        s_hardware_list,
+        [
+            'uuid',
+            'name',
+            'cpus',
+            'memory_mb',
+            'local_gb',
+            'enclosure_group_name',
+            'server_hardware_type_name'
+        ],
+        field_labels=[
+            'UUID',
+            'Name',
+            'CPUs',
+            'Memory MB',
+            'Local GB',
+            'Enclosure Group Name',
+            'Server Hardware Type Name'
+        ]
+    )
+
+
+def _interactive_template(spt_list):
+    template_selected = None
+    while not template_selected:
         input_id = common.print_prompt(
             spt_list,
             [
@@ -176,133 +406,104 @@ def do_node_create(args):
             'Server Hardware Type Name'
         ]
     )
+    return template_selected
 
-    s_hardware_list = node_creator.get_server_hardware_list(
-        template_selected
-    )
 
-    node_creator.set_attributes_to_object(s_hardware_list)
-    common.assign_elements_with_new_id(s_hardware_list)
+def _remove_ironic_enrolled(node_creator, selected_server_hardware_list):
+    not_enrolled = []
+    for server_hardware in selected_server_hardware_list:
+        if node_creator.is_enrolled_on_ironic(server_hardware):
+            print(('It was not possible to create the node, the '
+                   'Server Hardware %s is enrolled on Ironic.') %
+                  server_hardware.get('name'))
+        else:
+            not_enrolled.append(server_hardware)
+    return not_enrolled
 
-    if args.number:
-        print(("Creating %(number_of_nodes)s nodes with the specific "
-               "Server Hardware") % {'number_of_nodes': args.number})
+
+def _create_nodes(node_creator, not_enrolled_server_hardware, args,
+                  template_selected):
+    if not_enrolled_server_hardware:
+        print('Creating nodes to represent the following Server Hardware.')
         common.print_prompt(
-            [s_hardware_list[0]],
+            not_enrolled_server_hardware,
             [
+                'name',
+                'cpus',
+                'memory_mb',
+                'local_gb',
+                'enclosure_group_name',
+                'server_hardware_type_name'
+            ],
+            field_labels=[
+                'Name',
+                'CPUs',
+                'Memory MB',
+                'Local GB',
+                'Enclosure Group Name',
+                'Server Hardware Type Name'
+            ]
+        )
+        for server_hardware in not_enrolled_server_hardware:
+            if node_creator.is_server_profile_applied(
+                    server_hardware):
+                print('The Server Hardware %s is in use by OneView.' %
+                      server_hardware.get('name'))
+
+            node = node_creator.create_node(
+                args, server_hardware, template_selected
+            )
+
+            print('Node ' + node.uuid + ' was created!')
+
+
+def _interactive_server_hardware(s_hardware_list):
+    print('Listing compatible Server Hardware objects...')
+
+    s_hardware_ids_selected = []
+    invalid_server_hardware = True
+    while invalid_server_hardware:
+        input_id = common.print_prompt(
+            s_hardware_list,
+            [
+                'id',
+                'name',
                 'cpus',
                 'memory_mb',
                 'local_gb',
                 'cpu_arch',
                 'enclosure_group_name',
-                'server_hardware_type_name'
+                'server_hardware_type_name',
+                'enrolled'
             ],
+            "Enter a space separated list of Server Hardware "
+            "ids you want to use, e.g. 1 2 3 4. ('q' to quit)> ",
             field_labels=[
+                'Id',
+                'Name',
                 'CPUs',
                 'Memory MB',
-                'Disk GB',
+                'Local GB',
                 'CPU Arch',
                 'Enclosure Group Name',
-                'Server Hardware Type Name'
+                'Server Hardware Type Name',
+                'Enrolled'
             ]
         )
+        if input_id == 'q':
+            sys.exit()
 
-        nodes_created = 0
-        for node_index in range(args.number):
-            node = common.get_element_by_id(s_hardware_list, node_index + 1)
+        s_hardware_ids_selected = input_id.split()
+        invalid_server_hardware = common.is_entry_invalid(
+            s_hardware_ids_selected, s_hardware_list)
 
-            if node is None:
-                print("{} nodes created.".format(nodes_created))
-                break
-            elif node_creator.is_enrolled_on_ironic(node):
-                print(('Server Hardware %(server_hardware)s is already '
-                       'enrolled on Ironic.') % {'server_hardware':
-                                                 node.get("uuid")})
-            else:
-                if common.is_server_profile_applied(node):
-                    print(('Server Hardware %(server_hardware)s is in use by '
-                           'OneView.') % {'server_hardware':
-                                          node.get("uuid")})
+        s_hardware_ids_selected = input_id.split()
 
-                node_creator.create_node(args, node, template_selected)
-                nodes_created += 1
+    server_hardware_selected_list = []
+    for server_hardware_id in s_hardware_ids_selected:
+        server_hardware = common.get_element_by_id(
+            s_hardware_list, server_hardware_id
+        )
+        server_hardware_selected_list.append(server_hardware)
 
-        print('Node Creation Finished.')
-
-    else:
-        print('Listing compatible Server Hardware objects...')
-
-        invalid_server_hardwares = True
-        while invalid_server_hardwares:
-            input_id = common.print_prompt(
-                s_hardware_list,
-                [
-                    'id',
-                    'name',
-                    'cpus',
-                    'memory_mb',
-                    'local_gb',
-                    'cpu_arch',
-                    'enclosure_group_name',
-                    'server_hardware_type_name',
-                    'enrolled'
-                ],
-                "Enter a space separated list of Server Hardware "
-                "ids you want to use, e.g. 1 2 3 4. ('q' to quit)> ",
-                field_labels=[
-                    'Id',
-                    'Name',
-                    'CPUs',
-                    'Memory MB',
-                    'Disk GB',
-                    'CPU Arch',
-                    'Enclosure Group Name',
-                    'Server Hardware Type Name',
-                    'Enrolled'
-                ]
-            )
-            if input_id == 'q':
-                sys.exit()
-
-            s_hardware_ids_selected = input_id.split()
-            invalid_server_hardwares = common.is_entry_invalid(
-                s_hardware_ids_selected, s_hardware_list)
-
-        for server_hardware_id in s_hardware_ids_selected:
-            server_hardware_selected = common.get_element_by_id(
-                s_hardware_list, server_hardware_id
-            )
-            if node_creator.is_enrolled_on_ironic(server_hardware_selected):
-                print(('It was not possible create the node, this '
-                       'Server Hardware is enrolled on Ironic.'))
-            else:
-                print('Creating a node to represent the following Server '
-                      'Hardware.')
-                common.print_prompt(
-                    [server_hardware_selected],
-                    [
-                        'name',
-                        'cpus',
-                        'memory_mb',
-                        'local_gb',
-                        'enclosure_group_name',
-                        'server_hardware_type_name'
-                    ],
-                    field_labels=[
-                        'Name',
-                        'CPUs',
-                        'Memory MB',
-                        'Local GB',
-                        'Server Group Name',
-                        'Server Hardware Type Name'
-                    ]
-                )
-                if common.is_server_profile_applied(
-                        server_hardware_selected):
-                    print('This Server Hardware is in use by OneView.')
-
-                node = node_creator.create_node(
-                    args, server_hardware_selected, template_selected
-                )
-
-                print('Node ' + node.uuid + ' was created!')
+    return server_hardware_selected_list

--- a/ironic_oneview_cli/create_port_shell/commands.py
+++ b/ironic_oneview_cli/create_port_shell/commands.py
@@ -52,6 +52,7 @@ class PortCreator(object):
                 # to peform a deploy.
                 if virtual_port.get('portFunction') == 'a':
                     return virtual_port.get('mac').lower()
+            return None
         else:
             raise exceptions.OneViewResourceNotFoundError(
                 "There is no Ethernet port on the Server Hardware: %s"

--- a/ironic_oneview_cli/exceptions.py
+++ b/ironic_oneview_cli/exceptions.py
@@ -27,19 +27,17 @@ class Unauthorized(ClientException):
     """Unauthorized."""
 
 
-class OneViewConnectionError(ClientException):
-    def __init__(self, message=None):
-        self.message = message
-        super(OneViewConnectionError, self).__init__(message)
+class OneViewConnectionError(Exception):
+    def __init__(self, value):
+        self.value = value
 
     def __str__(self):
-        return repr(self.message)
+        return repr(self.value)
 
 
-class OneViewResourceNotFoundError(ClientException):
-    def __init__(self, message=None):
-        self.message = message
-        super(OneViewResourceNotFoundError, self).__init__(message)
+class OneViewResourceNotFoundError(Exception):
+    def __init__(self, value):
+        self.value = value
 
     def __str__(self):
-        return repr(self.message)
+        return repr(self.value)

--- a/ironic_oneview_cli/facade.py
+++ b/ironic_oneview_cli/facade.py
@@ -81,18 +81,20 @@ class Facade(object):
     # OneView actions
     # =========================================================================
     def get_server_hardware(self, uri):
+        if not uri:
+            return None
         uuid = common.get_uuid_from_uri(uri)
         return self.hponeview_client.server_hardware.get(uuid)
 
     def get_server_profile_template(self, uri):
-        if uri is None:
-            return
+        if not uri:
+            return None
         uuid = common.get_uuid_from_uri(uri)
         return self.hponeview_client.server_profile_templates.get(uuid)
 
     def get_enclosure_group(self, uri):
-        if uri is None:
-            return
+        if not uri:
+            return None
         uuid = common.get_uuid_from_uri(uri)
         return self.hponeview_client.enclosure_groups.get(uuid)
 
@@ -104,24 +106,15 @@ class Facade(object):
         uuid = common.get_uuid_from_uri(uri)
         return self.hponeview_client.server_profiles.get(uuid)
 
-    def list_templates_compatible_with(self, server_hardware_list):
-        compatible_server_profile_list = []
-        server_hardware_type_list = []
-        server_group_list = []
-
-        for server_hardware in server_hardware_list:
-            server_hardware_type_list.append(
-                server_hardware.get('serverHardwareTypeUri'))
-            server_group_list.append(
-                server_hardware.get('serverGroupUri'))
-
+    def list_templates_compatible(self, server_hardware_list=None):
         spt_list = self.hponeview_client.server_profile_templates.get_all()
-        for spt in spt_list:
-            if (spt.get('serverHardwareTypeUri') in
-                    server_hardware_type_list and spt.get(
-                        'enclosureGroupUri') in server_group_list):
-                compatible_server_profile_list.append(spt)
-        return compatible_server_profile_list
+        if not server_hardware_list:
+            server_hardware_list = self.filter_server_hardware_available()
+        return common.get_server_profile_compatible(spt_list,
+                                                    server_hardware_list)
+
+    def list_all_templates(self):
+        return self.hponeview_client.server_profile_templates.get_all()
 
     def filter_server_hardware_available(self, filters=''):
         return self.hponeview_client.server_hardware.get_all(filter=filters)
@@ -140,7 +133,7 @@ class Facade(object):
         return redfish.rest_client(base_url=base_url, sessionkey=ilo_token)
 
     def get_server_hardware_mac_from_ilo(self, server_hardware):
-        """Get the MAC address from a server hardware using iLO.
+        """Get the MAC address from a server hardware using iLO
 
         :param: server_hardware: a server hardware uuid or uri
         :return: the MAC address

--- a/ironic_oneview_cli/shell.py
+++ b/ironic_oneview_cli/shell.py
@@ -565,7 +565,11 @@ def main():
         print("... terminating OneView node creation tool", file=sys.stderr)
         sys.exit(130)
     except Exception as e:
-        print(encodeutils.safe_encode(six.text_type(e)), file=sys.stderr)
+        ex_content = (getattr(e, 'value', '') or getattr(e, 'message', '') or
+                      getattr(e, 'msg', '') or
+                      'The operation could not be performed')
+        msg = encodeutils.safe_encode(six.text_type(ex_content))
+        print(msg, file=sys.stderr)
         sys.exit(1)
 
 

--- a/ironic_oneview_cli/tests/unit/test_unit_ironic_oneview_cli.py
+++ b/ironic_oneview_cli/tests/unit/test_unit_ironic_oneview_cli.py
@@ -359,3 +359,18 @@ class UnitTestIronicOneviewCli(unittest.TestCase):
         sh_id = common.get_server_hardware_id_from_node(ironic_node)
 
         self.assertEqual(sh_id, "22222")
+
+    def test_is_valid_logical_name(self, mock_facade):
+        self.assertTrue(common.is_valid_logical_name('blade1'))
+        self.assertTrue(common.is_valid_logical_name('Enclosure1_bay_2'))
+        self.assertTrue(common.is_valid_logical_name('blade-1'))
+
+        self.assertFalse(common.is_valid_logical_name(None))
+        self.assertFalse(common.is_valid_logical_name(''))
+        self.assertFalse(common.is_valid_logical_name('Enclosure1, bay 2'))
+
+    def test_normalize_logical_name(self, mock_facade):
+        self.assertEqual('Enclosure1_bay_2',
+                         common.normalize_logical_name('Enclosure1, bay 2'))
+        self.assertEqual('blade2', common.normalize_logical_name('blade2'))
+        self.assertEqual(None, common.normalize_logical_name(None))

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 minversion = 1.8
 skipsdist = True
-envlist = py27,py35,pep8,cover
+envlist = py27,py35,pylint,pep8,cover
 
 [testenv]
 usedevelop = True
@@ -32,8 +32,19 @@ deps = pylint
 # W0703: Too general exception Exception
 # E1101: Instance of 'Exception' has no 'message' member
 # R0912: Too many branches - FIX after non-interactive commands commit
+# C0325: Print function has unnecessary parentheses
+# W0231: Custom exceptions do not call the super
+# C0330: Indentation pattern incompatible with pep8
+# W0102: Default value {} for params
+# W0622: Import Python3 input()
+# E0401: six.moves throws import error
+# R0913: Many arguments
+# R0914: Many local variables
+# R0915: Many statements
+# R1710: Either all return statements in a function should return an expression, or none of them should
+# W0715: Exception arguments suggest string formatting might be intended
 commands =
-  pylint -f parseable -d C0111,C0103,W0703,E1101,R0912 ironic_oneview_cli --ignore=tests,shell.py
+  pylint -f parseable -d C0111,C0103,W0703,E1101,R0912,C0325,W0231,C0330,W0102,W0622,E0401,R0913,R0914,R0915,R1710,W0715 ironic_oneview_cli --ignore=tests,shell.py
 
 [testenv:venv]
 commands = {posargs}


### PR DESCRIPTION
The following commands are now available for noninteractive use:

- server-profile-template-list
- server-hardware-list
- flavor-create
- node-create